### PR TITLE
fix getAllMMKVInstanceIDs NPE

### DIFF
--- a/android/src/main/java/com/ammarahmed/mmkv/RNMMKVModule.java
+++ b/android/src/main/java/com/ammarahmed/mmkv/RNMMKVModule.java
@@ -187,6 +187,12 @@ public class RNMMKVModule extends ReactContextBaseJavaModule {
         HashMap<String, Object> allIDs = IdStore.getAll();
 
         WritableArray array = Arguments.createArray();
+
+        if (allIDs == null) {
+            promise.resolve(array);
+            return;
+        }
+
         for (String string : allIDs.keySet()) {
             array.pushString(string);
         }

--- a/index.d.ts
+++ b/index.d.ts
@@ -226,7 +226,7 @@ declare module MMKVStorage {
      * Get all MMKV Instance IDs.
      *
      */
-    getAllMMKVInstanceIDs(): Promise<object>;
+    getAllMMKVInstanceIDs(): Promise<Array<string>>;
 
     /**
      *


### PR DESCRIPTION
`IdStore.getAll()` could be null if there is no MMKV instance. Return an empty array If `IdStore.getAll()` is null.