### PR TITLE
enable multi process in ios

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -9,7 +9,10 @@ import {
 
 import MMKV from 'react-native-mmkv-storage';
 
-const MMKVStorage = new MMKV.Loader().withEncryption().initialize();
+const MMKVStorage = new MMKV.Loader()
+  .withEncryption()
+  .setProcessingMode(MMKV.MODES.MULTI_PROCESS)
+  .initialize();
 
 const App = () => {
   const [stringValue, setStringValue] = useState('');

--- a/ios/MMKVStorage.m
+++ b/ios/MMKVStorage.m
@@ -48,7 +48,7 @@ RCT_EXPORT_MODULE()
          NSArray *paths = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
          NSString *libraryPath = (NSString *) [paths firstObject];
          NSString *rootDir = [libraryPath stringByAppendingPathComponent:@"mmkv"];
-         [MMKV initializeMMKV:rootDir];
+        [MMKV initializeMMKV:rootDir groupDir:libraryPath logLevel:MMKVLogNone];
         
         secureStorage = [[SecureStorage alloc]init];
         IdStore = [[IDStore alloc] initWithMMKV:[MMKV mmkvWithID:@"mmkvIdStore"]];


### PR DESCRIPTION
Close #47 

Following this: https://github.com/Tencent/MMKV/wiki/iOS_tutorial#configuration, we need to initialize MMKV with the rootPath parameter to use MultiProcess mode.

Without this, is crashing on ios:

`Assertion failed: (0), function +[MMKV mmkvWithID:cryptKey:rootPath:mode:], file /example/ios/Pods/MMKV/iOS/MMKV/MMKV/libMMKV.mm, line 181.`