### PR TITLE
Provide null as possible type for get operations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -56,7 +56,7 @@ declare module MMKVStorage {
      * Get a string value for a given key.
      * @param {String} key
      */
-    getStringAsync(key: string): Promise<string>;
+    getStringAsync(key: string): Promise<string | null>;
 
     /**
      * Set a number value to storage for a given key.
@@ -71,7 +71,7 @@ declare module MMKVStorage {
      * Get a number value for a given key
      * @param {String} key
      */
-    getIntAsync(key: string): Promise<number>;
+    getIntAsync(key: string): Promise<number | null>;
 
     /**
      * Set a boolean value to storag for a given key.
@@ -86,7 +86,7 @@ declare module MMKVStorage {
      * Get a boolean value for a given key.
      * @param {String} key
      */
-    getBoolAsync(key: string): Promise<boolean>;
+    getBoolAsync(key: string): Promise<boolean | null>;
 
     /**
      * Set an Object to storage for a given key.
@@ -101,7 +101,7 @@ declare module MMKVStorage {
      * Get an Object from storage for a given key.
      * @param {String} key
      */
-    getMapAsync(key: string): Promise<object>;
+    getMapAsync(key: string): Promise<object | null>;
     /**
      * Set an array to the db.
      * @param {String} key
@@ -113,7 +113,7 @@ declare module MMKVStorage {
      * @param {String} key
      */
 
-    getArrayAsync(key: string): Promise<Array<any>>;
+    getArrayAsync(key: string): Promise<Array<any> | null>;
     /**
      * Retrieve multiple Objects for a given array of keys. Currently will work only if data for all keys is an Object.
      * Arrays will also be returned but wrappen in a object.
@@ -147,7 +147,7 @@ declare module MMKVStorage {
      * @param {String} key
      * @param {Function} callback
      */
-    getString(key: string, callback: Function): string;
+    getString(key: string, callback: Function): string | null;
 
     /**
      * Set a number value to storage for a given key.
@@ -163,7 +163,7 @@ declare module MMKVStorage {
      * @param {String} key
      * @param {Function} callback
      */
-    getInt(key: string, callback: Function): number;
+    getInt(key: string, callback: Function): number | null;
 
     /**
      * Set a boolean value to storag for a given key.
@@ -179,7 +179,7 @@ declare module MMKVStorage {
      * @param {String} key
      * @param {Function} callback
      */
-    getBool(key: string, callback: Function): boolean;
+    getBool(key: string, callback: Function): boolean | null;
 
     /**
      * Set an Object to storage for a given key.
@@ -195,7 +195,7 @@ declare module MMKVStorage {
      * @param {String} key
      * @param {Function} callback
      */
-    getMap(key: string, callback: Function): object;
+    getMap(key: string, callback: Function): object | null;
     /**
      * Set an array to the db.
      * @param {String} key
@@ -209,7 +209,7 @@ declare module MMKVStorage {
      * @param {Function} callback
      */
 
-    getArray(key: string, callback: Function): Array<any>;
+    getArray(key: string, callback: Function): Array<any> | null;
     /**
      * Retrieve multiple Objects for a given array of keys. Currently will work only if data for all keys is an Object.
      * Arrays will also be returned but wrappen in a object.


### PR DESCRIPTION
When getting a key this implementation returns null if the key isn't set. This isn't yet reflected in the typescript definitions. When working with strict mode/strict null checking it's important to tell explicitly that a value can be null.