### PR TITLE
fix return type on useMMKVStorage hook to pass ts typecheck script

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare function MMKVStorage(): any;
 
-export declare function useMMKVStorage(key: string, storage: MMKVStorage.API): [any, (value?: any) => void];
+export declare function useMMKVStorage<T extends any>(key: string, storage: MMKVStorage.API): [T, (value?: T) => void];
 
 export default MMKVStorage;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare function MMKVStorage(): any;
 
-export declare function useMMKVStorage(key:string,storage:MMKVStorage.API):[value:any,setValue:(value?:any)=>void];
+export declare function useMMKVStorage(key: string, storage: MMKVStorage.API): [any, (value?: any) => void];
 
 export default MMKVStorage;
 


### PR DESCRIPTION
When compiling my project with `react-native-mmkv-storage` as a dependency, I get a compilation error related to the return type on the `useMMKVStorage` hook declaration.

```
> tsc  --noEmit --project ./tsconfig.typeCheck.json

node_modules/react-native-mmkv-storage/index.d.ts:3:82 - error TS1005: ',' expected.

3 export declare function useMMKVStorage(key:string,storage:MMKVStorage.API):[value:any,setValue:(value?:any)=>void];
```

I cannot simply exclude this file from my typecheck config because any file imported within a project will always get type checked, and importing the package `import MMKVStorage from 'react-native-mmkv-storage';` links to `index.d.ts` which causes the error. This is causing a CI error in my project.

I propose in this PR simply updating the return type so that the compile script completes without error.

