### PR TITLE
fix: improved types definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,11 @@
 declare function MMKVStorage(): any;
 
-interface T extends any {}
-
-export declare function useMMKVStorage(
+export declare function useMMKVStorage<T = any>(
   key: string,
   storage: MMKVStorage.API
 ): [T, (value?: T | ((prevValue: T) => T)) => void];
 
-export declare function create(storage:MMKVStorage.API):(key:string) => [T, (value?: T | ((prevValue: T) => T)) => void];
+export declare function create(storage:MMKVStorage.API):<T = any>(key:string) => [T, (value?: T | ((prevValue: T) => T)) => void];
 
 export default MMKVStorage;
 


### PR DESCRIPTION
The current types definitions doesn't allow a proper Typescript typing of the useMMKVStorage hook and its create method.
With these changes, we can now use it like this:
`const [value, setValue] = useMMKVStorage<string>('my-key', mmkv); // Typescript now knows that "value" should be string`