### PR TITLE
Trigger useMMKVStorage change when removeItem is called

### DIFF
--- a/src/hooks/useMMKV.js
+++ b/src/hooks/useMMKV.js
@@ -38,6 +38,9 @@ export const useMMKVStorage = (key, storage) => {
           return;
         }
       }
+    } else {
+      setValue(null);
+      setValueType(null);
     }
   }, []);
 


### PR DESCRIPTION
Calling removeItem does not trigger useMMKVStorage to update the current value as the updateValue function does not do anything if the key no longer exists.
This diff fixes this issue by calling setValue(null) if the key does not exist in storage.