### PR TITLE
Move getAllMMKVInstanceIDs to class level

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -250,6 +250,13 @@ declare module MMKVStorage {
 
     /**
      *
+     * Get all MMKV Instance IDs.
+     *
+     */
+    static getAllMMKVInstanceIDs(): Promise<Array<string>>;
+
+    /**
+     *
      * Get all MMKV Instance IDs that are currently loaded
      *
      */

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,7 +32,10 @@ declare module MMKVStorage {
 
   export const ACCESSIBLE: ACCESSIBLE;
   
+  export declare function getAllMMKVInstanceIDs(): string[];
+  export declare function getCurrentMMKVInstanceIDs(): Record<string, boolean>;
 
+  export const IDSTORE_ID: string;
 
   const myVar: string;
 
@@ -250,26 +253,11 @@ declare module MMKVStorage {
 
     /**
      *
-     * Get all MMKV Instance IDs.
-     *
-     */
-    static getAllMMKVInstanceIDs(): string[];
-
-    /**
-     *
      * Get all MMKV Instance IDs that are currently loaded
      *
      */
 
     getCurrentMMKVInstanceIDs(): Record<string, boolean>;
-
-    /**
-     *
-     * Get all MMKV Instance IDs that are currently loaded
-     *
-     */
-
-    static getCurrentMMKVInstanceIDs(): Record<string, boolean>;
 
     encryption: encryption;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -246,14 +246,14 @@ declare module MMKVStorage {
      * Get all MMKV Instance IDs.
      *
      */
-    getAllMMKVInstanceIDs(): Promise<Array<string>>;
+    getAllMMKVInstanceIDs(): string[];
 
     /**
      *
      * Get all MMKV Instance IDs.
      *
      */
-    static getAllMMKVInstanceIDs(): Promise<Array<string>>;
+    static getAllMMKVInstanceIDs(): string[];
 
     /**
      *
@@ -261,7 +261,15 @@ declare module MMKVStorage {
      *
      */
 
-    getCurrentMMKVInstanceIDs(): Promise<Array<string>>;
+    getCurrentMMKVInstanceIDs(): Record<string, boolean>;
+
+    /**
+     *
+     * Get all MMKV Instance IDs that are currently loaded
+     *
+     */
+
+    static getCurrentMMKVInstanceIDs(): Record<string, boolean>;
 
     encryption: encryption;
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 import { useMMKVStorage as useMMKV } from "./src/hooks/useMMKV";
 import { ACCESSIBLE, MODES } from "./src/utils";
+import { getCurrentMMKVInstanceIDs } from "./src/initializer";
+import { default as IDStore } from "./src/mmkv/IDStore";
+
 export const useMMKVStorage = useMMKV;
 export const create = require("./src/hooks/useMMKV").create;
 
@@ -11,6 +14,9 @@ const MMKVStorage = {
   API: API,
   MODES: MODES,
   ACCESSIBLE: ACCESSIBLE,
+  getAllMMKVInstanceIDs: IDStore.getAllMMKVInstanceIDs,
+  getCurrentMMKVInstanceIDs: getCurrentMMKVInstanceIDs,
+  IDSTORE_ID: IDStore.STORE_ID,
 };
 
 export default MMKVStorage;

--- a/index.js
+++ b/index.js
@@ -1,15 +1,16 @@
-import {useMMKVStorage as useMMKV} from "./src/hooks/useMMKV"
-import { ACCESSIBLE, MODES } from './src/utils';
+import { useMMKVStorage as useMMKV } from "./src/hooks/useMMKV";
+import { ACCESSIBLE, MODES } from "./src/utils";
 export const useMMKVStorage = useMMKV;
 export const create = require("./src/hooks/useMMKV").create;
 
-const Loader = require('./src/loader').default;
+const Loader = require("./src/loader").default;
+const API = require("./src/api").default;
 
 const MMKVStorage = {
-  Loader:Loader,
+  Loader: Loader,
+  API: API,
   MODES: MODES,
-  ACCESSIBLE : ACCESSIBLE,
-}
+  ACCESSIBLE: ACCESSIBLE,
+};
 
 export default MMKVStorage;
-

--- a/src/api.js
+++ b/src/api.js
@@ -7,6 +7,11 @@ import IDStore from "./mmkv/IDStore";
 import { promisify } from "./utils";
 
 export default class API {
+  static getAllMMKVInstanceIDs() {
+    let instances = IDStore.getAll();
+    return Object.keys(instances);
+  }
+
   constructor(args) {
     this.instanceID = args.instanceID;
     this.initWithEncryption = args.initWithEncryption;
@@ -274,8 +279,7 @@ export default class API {
   }
 
   getAllMMKVInstanceIDs() {
-    let instances = IDStore.getAll();
-    return Object.keys(instances);
+    return API.getAllMMKVInstanceIDs();
   }
 
   removeItem(key) {

--- a/src/api.js
+++ b/src/api.js
@@ -269,11 +269,11 @@ export default class API {
     return func();
   };
 
-getCurrentMMKVInstanceIDs() {
+  getCurrentMMKVInstanceIDs() {
     return currentInstancesStatus;
   }
 
- getAllMMKVInstanceIDs() {
+  getAllMMKVInstanceIDs() {
     let instances = IDStore.getAll();
     return Object.keys(instances);
   }
@@ -289,7 +289,7 @@ getCurrentMMKVInstanceIDs() {
 
   clearStore() {
     let cleared = handleAction(global.clearMMKV, this.instanceID);
-    global.setBoolMMKV(this.instanceID,true,this.instanceID)
+    global.setBoolMMKV(this.instanceID, true, this.instanceID);
     return cleared;
   }
 }

--- a/src/api.js
+++ b/src/api.js
@@ -2,20 +2,11 @@ import encryption from "./encryption";
 import EventManager from "./eventmanager";
 import { handleAction } from "./handlers";
 import indexer from "./indexer/indexer";
-import { currentInstancesStatus } from "./initializer";
-import IDStore from "./mmkv/IDStore";
+import { getCurrentMMKVInstanceIDs } from "./initializer";
+import { default as IDStore } from "./mmkv/IDStore";
 import { promisify } from "./utils";
 
 export default class API {
-  static getAllMMKVInstanceIDs() {
-    let instances = IDStore.getAll();
-    return Object.keys(instances);
-  }
-
-  static getCurrentMMKVInstanceIDs() {
-    return currentInstancesStatus;
-  }
-
   constructor(args) {
     this.instanceID = args.instanceID;
     this.initWithEncryption = args.initWithEncryption;
@@ -279,11 +270,11 @@ export default class API {
   };
 
   getCurrentMMKVInstanceIDs() {
-    return API.getCurrentMMKVInstanceIDs();
+    return getCurrentMMKVInstanceIDs();
   }
 
   getAllMMKVInstanceIDs() {
-    return API.getAllMMKVInstanceIDs();
+    return IDStore.getAllMMKVInstanceIDs();
   }
 
   removeItem(key) {

--- a/src/api.js
+++ b/src/api.js
@@ -12,6 +12,10 @@ export default class API {
     return Object.keys(instances);
   }
 
+  static getCurrentMMKVInstanceIDs() {
+    return currentInstancesStatus;
+  }
+
   constructor(args) {
     this.instanceID = args.instanceID;
     this.initWithEncryption = args.initWithEncryption;
@@ -275,7 +279,7 @@ export default class API {
   };
 
   getCurrentMMKVInstanceIDs() {
-    return currentInstancesStatus;
+    return API.getCurrentMMKVInstanceIDs();
   }
 
   getAllMMKVInstanceIDs() {

--- a/src/initializer.js
+++ b/src/initializer.js
@@ -3,6 +3,14 @@ import IDStore from "./mmkv/IDStore";
 export const currentInstancesStatus = {};
 
 /**
+ * Get current instance ID status for instances
+ * loaded since application started
+ */
+export function getCurrentMMKVInstanceIDs() {
+  return { ...currentInstancesStatus };
+}
+
+/**
  *
  * Initialize function is used to create
  * the storage or load the storage if

--- a/src/mmkv/IDStore.js
+++ b/src/mmkv/IDStore.js
@@ -75,10 +75,20 @@ function getAll() {
   return storeUnits;
 }
 
+/**
+ * Get all the instance ids for instances
+ * that were loaded since the app was installed
+ */
+function getAllMMKVInstanceIDs() {
+  return Object.keys(getAll());
+}
+
 export default {
   getAll,
   getAlias,
+  getAllMMKVInstanceIDs,
   add,
   exists,
   encrypted,
+  STORE_ID,
 };


### PR DESCRIPTION
From #117 

This PR:

* Adds `getAllMMKVInstanceIDs` and `getCurrentMMKVInstanceIDs`. to the class level of `API`. 
* Ensures that `API` is exported at the module level ( the TypeScript definition appears to indicate that's desired ).
* Fixes the type definitions of both methods ( neither is async ). 

It retains the prior instance level method for anyone that was previously depending on that method being available there, but has the instance level method call the class level method.