### PR TITLE
Improve types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare function MMKVStorage(): any;
 
-type StoredValueAndSetter<T> = [T | null, (value?: T | ((prevValue: T) => T)) => void];
+type StoredValueAndSetter<T> = [T | null, (value: T | ((prevValue: T) => T)) => void];
 
 export declare function useMMKVStorage<T = any>(
   key: string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,13 @@
 declare function MMKVStorage(): any;
 
+type StoredValueAndSetter<T> = [T | null, (value?: T | ((prevValue: T) => T)) => void];
+
 export declare function useMMKVStorage<T = any>(
   key: string,
   storage: MMKVStorage.API
-): [T, (value?: T | ((prevValue: T) => T)) => void];
+): StoredValueAndSetter<T>;
 
-export declare function create(storage:MMKVStorage.API):<T = any>(key:string) => [T, (value?: T | ((prevValue: T) => T)) => void];
+export declare function create(storage:MMKVStorage.API):<T = any>(key:string) => StoredValueAndSetter<T>;
 
 export default MMKVStorage;
 


### PR DESCRIPTION
Add `null` as a possible return value in `useMMKVStorage`. This forces users to handle this case.

Also, I removed the `?` type from the setter. This prevents the stored value from potentially going out of sync with the passed in type. For example, if the type of value is `string` and the user calls the setter without passing in a value (`setValue()`), `undefined` is stored, which is now out of sync with the value type of `string`. If users wants to pass `undefined`, they can set the value type to `string | undefined`. 