### PR TITLE
fix: only check value is null or undefined

### DIFF
--- a/src/hooks/functions.js
+++ b/src/hooks/functions.js
@@ -1,7 +1,7 @@
 import {types,methods} from "./constants";
 
 export const getDataType = (value) => {
-  if (!value) return null;
+  if (value === null || value === undefined) return null;
   let type = Array.isArray(value) ? "array" : typeof value;
   return type;
 };


### PR DESCRIPTION
Fix issus #163 when set falsy value (`false`, `0`, empty string) except `null`, `undefined`