### PR TITLE
Clarify map incompatibility

### DIFF
--- a/docs/datatypes.md
+++ b/docs/datatypes.md
@@ -111,3 +111,6 @@ flex-direction: column;
 </div>
 
 </div>
+
+
+The Map data type is **not** supported.

--- a/index.d.ts
+++ b/index.d.ts
@@ -226,7 +226,6 @@ declare module MMKVStorage {
      * Set an Object to storage for a given key.
      *
      * Note that this function does **not** work with the Map data type
-     *
      * @param {String} key
      * @param {Object} value
      * @param {Callback<boolean>} callback

--- a/index.d.ts
+++ b/index.d.ts
@@ -122,6 +122,7 @@ declare module MMKVStorage {
     /**
      * Set an Object to storage for a given key.
      *
+     * Note that this function does **not** work with the Map data type.
      * @param {String} key
      * @param {Object} value
      *
@@ -223,6 +224,8 @@ declare module MMKVStorage {
 
     /**
      * Set an Object to storage for a given key.
+     *
+     * Note that this function does **not** work with the Map data type
      *
      * @param {String} key
      * @param {Object} value


### PR DESCRIPTION
I just spent a significant amount of time, debugging why the library did not store data persistently for me, even though I followed the docs pretty closely and did not use expo.

It was not until I stumbled upon #119 that I found out about maps not being supported.

In this PR I added warnings about this to some places where they will hopefully be found by others who are about to make the same mistake I did.