### PR TITLE
Fix multiple META-INF/MANIFEST.MF path error during detox build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -85,7 +85,7 @@ android {
   }
 
   packagingOptions {
-    excludes = ["**/libc++_shared.so","**/libjsi.so","**/libreactnativejni.so"]
+    excludes = ["**/libc++_shared.so","**/libjsi.so","**/libreactnativejni.so", "META-INF/MANIFEST.MF"]
   }
   
   configurations {


### PR DESCRIPTION
This fixes an error that occurs when building a react-native 0.66 app with react-native-mmkv-storage **with detox**.

The following error occurs:
```
Execution failed for task ':react-native-mmkv-storage:mergeDebugAndroidTestJavaResource'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.MergeJavaResWorkAction
   > 24 files found with path 'META-INF/MANIFEST.MF' from inputs:
```

Seems like `react-native-mmkv` ran into the same issue: https://github.com/mrousavy/react-native-mmkv/pull/194/files