### PR TITLE
fix: secure storage unable to read data from keychain

### DIFF
--- a/ios/SecureStorage.m
+++ b/ios/SecureStorage.m
@@ -5,6 +5,7 @@
 #endif
 
 #import "SecureStorage.h"
+#import <UIKit/UIKit.h>
 
 
 @implementation SecureStorage : NSObject
@@ -44,6 +45,14 @@ NSString *serviceName = nil;
     @try {
         [self handleAppUninstallation];
         NSString *value = [self searchKeychainCopyMatching:key];
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            int readAttempts = 0;
+            // See: https://github.com/ammarahm-ed/react-native-mmkv-storage/issues/195
+            while (![[UIApplication sharedApplication] isProtectedDataAvailable] && readAttempts++ < 100) {
+                // sleep 25ms before another attempt
+                usleep(25000);
+            }
+        });
         if (value == nil) {
             NSString* errorMessage = @"key does not present";
           


### PR DESCRIPTION
In some cases, the app could be initialised before secure storage was ready to be read (`isProtectedDataAvailable` was false, [see docs](https://developer.apple.com/documentation/uikit/uiapplication/1622925-isprotecteddataavailable)). This could lead to data seemingly being "lost", while in fact it was just the keychain not being ready to read the data yet.

This introduces a workaround that will wait for the keychain to be ready before fully initialising the app.

fixes #195