### PR TITLE
Add note for AppCenter users

### DIFF
--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -82,6 +82,8 @@ echo "cmake.dir=$ANDROID_HOME/cmake/3.10.2.4988404" >> android/local.properties
 ls $ANDROID_HOME/cmake/ # 3.10.2.4988404  3.6.4111459
 ```
 
+**Note: AppCenter builds will need to include the above in appcenter-pre-build.sh**
+
 ### iOS
 
 1. Update your project deployment target to `11.0`
@@ -95,6 +97,7 @@ platform :ios, '11.0'
 ## No Debug Mode
 
 You cannot attach chrome debugger if you are using >=0.5.0 version of this library since debugging is not available when JSI modules are used. You can use Flipper to debug if necessary.
+
 
 ##
 

--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -98,7 +98,6 @@ platform :ios, '11.0'
 
 You cannot attach chrome debugger if you are using >=0.5.0 version of this library since debugging is not available when JSI modules are used. You can use Flipper to debug if necessary.
 
-
 ##
 
 **Read Next:** [Creating an MMKV Instance](creatinginstance.md)


### PR DESCRIPTION
This caught me out when upgrading, 

Previously there was a fix to brew uninstall cmake to get around build failures in AppCenter. (See https://github.com/ammarahm-ed/react-native-mmkv-storage/issues/132)

Now with 0.70^ this should no longer be done, we should also do the following in appcenter-prebuild.sh to fix builds.

```
echo "cmake.dir=$ANDROID_HOME/cmake/3.10.2.4988404" >> android/local.properties
```

