### PR TITLE
fix: check for undefined on pathname

### DIFF
--- a/dist/src/module/index.js
+++ b/dist/src/module/index.js
@@ -1,5 +1,5 @@
 //@ts-ignore
-var isDebugMode = global.location && global.location.pathname.includes('/debugger-ui');
+var isDebugMode = global.location && global.location.pathname && global.location.pathname.includes('/debugger-ui');
 export var mmkvBridgeModule = !isDebugMode
     ? require('react-native').NativeModules.MMKVNative
     : {

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -1,7 +1,7 @@
 import { MMKVJsiModule } from '../types';
 
 //@ts-ignore
-const isDebugMode = global.location && global.location.pathname.includes('/debugger-ui');
+const isDebugMode = global.location && global.location.pathname && global.location.pathname.includes('/debugger-ui');
 
 export const mmkvBridgeModule: {
   /**


### PR DESCRIPTION
Checking to ensure that `global.location.pathname` is not undefined before accessing the `includes` function. This PR is to fix https://github.com/ammarahm-ed/react-native-mmkv-storage/issues/251.