### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ const userStorage = new MMKVLoader()
   .withInstanceID('userdata')
   .initialize();
 
-const settingsStorage = new MMKVStorage.Loader().withInstanceID('settings').initialize();
+const settingsStorage = new MMKVLoader().withInstanceID('settings').initialize();
 ```
 
 ### **Full encryption support**


### PR DESCRIPTION
Update example to initialize `settingsStorage` variable with `MMKVLoader` in place of the deprecated `MMKVStorage.Loader()`