### PR TITLE
Encrypted Storage Bugfixes

### DIFF
--- a/src/initializer.ts
+++ b/src/initializer.ts
@@ -33,6 +33,10 @@ export function initialize(id: string) {
     return initWithEncryptionWithoutSecureStorage(opts);
   }
 
+  if (opts.alias && !mmkvJsiModule.secureKeyExists(opts.alias)) {
+    return initWithEncryptionUsingNewKey(opts);
+  }
+
   if (IDStore.exists(id)) {
     if (!IDStore.encrypted(id)) {
       return initWithoutEncryption(opts);
@@ -43,9 +47,6 @@ export function initialize(id: string) {
 
   if (!opts.initWithEncryption) {
     return initWithoutEncryption(opts);
-  }
-  if (opts.alias && !mmkvJsiModule.secureKeyExists(opts.alias)) {
-    return initWithEncryptionUsingNewKey(opts);
   }
   return initWithEncryptionUsingOldKey(opts);
 }

--- a/src/initializer.ts
+++ b/src/initializer.ts
@@ -29,6 +29,10 @@ export function initialize(id: string) {
     mmkvJsiModule.setMMKVServiceName(opts.alias, opts.serviceName);
   }
 
+  if (opts.initWithEncryption && !opts.secureKeyStorage) {
+    return initWithEncryptionWithoutSecureStorage(opts);
+  }
+
   if (IDStore.exists(id)) {
     if (!IDStore.encrypted(id)) {
       return initWithoutEncryption(opts);
@@ -39,9 +43,6 @@ export function initialize(id: string) {
 
   if (!opts.initWithEncryption) {
     return initWithoutEncryption(opts);
-  }
-  if (!opts.secureKeyStorage) {
-    return initWithEncryptionWithoutSecureStorage(opts);
   }
   if (opts.alias && !mmkvJsiModule.secureKeyExists(opts.alias)) {
     return initWithEncryptionUsingNewKey(opts);


### PR DESCRIPTION
This fixes a few issues I've seen in a production app with encrypted storage.

This moves the `initWithEncryptionWithoutSecureStorage` call higher up because the app was crashing when trying to access secure storage on an instance that did not use secure storage. It was going down the `if (IDStore.exists(id))` path which ultimately tried to encrypt with a key stored in secure storage even though it was configured to not use secure storage. This fixes #265 

This also moves the `initWithEncryptionUsingNewKey` call higher up because the app got into a bad state where the `IDStore.exists(id)` call was returning true but the `mmkvJsiModule.getSecureKey` call was returning nothing. I'm not sure how it got into the bad state but it may be related to the problem that was fixed by 0.8.0. If the secure key does not exist, it should use a new key instead of continually trying to use the nonexistent key.