### PR TITLE
removed unnecessary move

### DIFF
--- a/MMKV/Core/MMKV.cpp
+++ b/MMKV/Core/MMKV.cpp
@@ -562,7 +562,7 @@ bool MMKV::getBytes(MMKVKey_t key, mmkv::MMBuffer &result) {
     if (data.length() > 0) {
         try {
             CodedInputData input(data.getPtr(), data.length());
-            result = move(input.readData());
+            result = input.readData();
             return true;
         } catch (std::exception &exception) {
             MMKVError("%s", exception.what());


### PR DESCRIPTION
`input.readData()` is a r-value, so moving it does not have any effect.

This fixes compiler warning:
`C/C++: .../react-native-mmkv-storage/MMKV/Core/MMKV.cpp:565:22: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]`