### PR TITLE
fix: Encryption typings

### DIFF
--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -13,6 +13,7 @@ Encrypt an already created instance of MMKV.
 | cryptKey         | no       | String  | Password to encrypt the storage                                                       |
 | secureKeyStorage | no       | boolean | Set to true of you want the library to store the password securely                    |
 | alias            | no       | String  | You can provide a custom alias for storage of password, by default instanceID is used |
+| accessibleMode   | no       | IOSAccessibleStates  | Choose the accessibility mode (iOS only)                                 |
 
 ```js
 import { MMKVLoader } from "react-native-mmkv-storage";
@@ -58,6 +59,7 @@ Change the encryption key of an encrypted instance of MMKV.
 | cryptKey         | yes      | String  | Password to encrypt the storage                                                       |
 | secureKeyStorage | no       | boolean | Set to true of you want the library to store the password securely                    |
 | alias            | no       | String  | You can provide a custom alias for storage of password, by default instanceID is used |
+| accessibleMode   | no       | IOSAccessibleStates  | Choose the accessibility mode (iOS only)                                 |
 
 ```js
 // Create an instance that is encrypted

--- a/docs/loaderclass.md
+++ b/docs/loaderclass.md
@@ -112,9 +112,9 @@ Choose the accessibility mode for secure key storage (IOS ONLY);
 
 **Arguments**
 
-| Name       | Required | Type                   | Description                   |
-|------------|----------|------------------------|-------------------------------|
-| accessible | yes      | MMKVStorage.ACCESSIBLE | Choose the accessibility mode |
+| Name       | Required | Type                 | Description                   |
+|------------|----------|----------------------|-------------------------------|
+| accessible | yes      | IOSAccessibleStates  | Choose the accessibility mode |
 
 ```js
 import { MMKVLoader, IOSAccessibleStates } from "react-native-mmkv-storage";

--- a/src/encryption.ts
+++ b/src/encryption.ts
@@ -108,7 +108,7 @@ export default class encryption {
    * @param alias Provide a custom alias to store the key with in secure storage
    * @param accessibleMode Set accessible mode for secure storage on ios devices
    */
-  changeEncryptionKey(key: string, secureKeyStorage = true, alias: string, accessibleMode: string) {
+  changeEncryptionKey(key: string, secureKeyStorage = true, alias?: string, accessibleMode?: string) {
     return this.encrypt(key, secureKeyStorage, alias, accessibleMode);
   }
 }

--- a/src/encryption.ts
+++ b/src/encryption.ts
@@ -60,7 +60,7 @@ export default class encryption {
    * @param accessibleMode Set accessible mode for secure storage on ios devices
    * @returns An object with alias and key
    */
-  encrypt(key: string, secureKeyStorage = true, alias: string, accessibleMode: string) {
+  encrypt(key?: string, secureKeyStorage = true, alias?: string, accessibleMode?: string) {
     if (accessibleMode) {
       this.accessibleMode = accessibleMode;
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,7 +15,7 @@ export type StorageOptions = {
   secureKeyStorage: boolean;
   /**
    * Set the AccessibleMode for iOS
-   * Import ACCESSIBLE from library to use it.
+   * Import IOSAccessibleStates from library to use it.
    */
   accessibleMode: string;
   /**


### PR DESCRIPTION
Currently if trying to use defafult for encryption we hit a type error

`mmkvInstance.encryption.encrypt() //TS2554: Expected 4 arguments, but got 0.`

All params for `changeEncryptionKey` are also required by typescript

`mmkvInstance.encryption.changeEncryptionKey('new-key'); // An argument for 'secureKeyStorage' was not provided`



This PR fixes the above and also makes some small docs updates