### PR TITLE
chore: allowing higher patch version of mmkv pod

### DIFF
--- a/react-native-mmkv-storage.podspec
+++ b/react-native-mmkv-storage.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m,mm}"
   s.requires_arc  = true
   s.dependency 'React-Core'
-  s.dependency 'MMKV', '1.2.13'
+  s.dependency 'MMKV', '~> 1.2.13'
 end


### PR DESCRIPTION
`~>` should allow using a higher version of mmkv instead of sticking to outdated patches.