### PR TITLE
Fix detox 0.71 error duplicated libc++_shared.so for Android builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -60,7 +60,8 @@ android {
             "META-INF/**",
             "**/libjsi.so",
             "**/libreact_nativemodule_core.so",
-            "**/libturbomodulejsijni.so"
+            "**/libturbomodulejsijni.so",
+            "**/libc++_shared.so"
       ]
     }
   }


### PR DESCRIPTION
## Description
Android builds were failing for detox 0.71 because of duplicated `libc++_shared.so`.

Should fix: https://github.com/ammarahm-ed/react-native-mmkv-storage/issues/321