### PR TITLE
fix detox 0.72 error duplicated libfbjni.so for Android builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,6 +58,7 @@ android {
     excludes = [
             "META-INF",
             "META-INF/**",
+            "**/libfbjni.so",
             "**/libjsi.so",
             "**/libreact_nativemodule_core.so",
             "**/libturbomodulejsijni.so",


### PR DESCRIPTION
## Description

Android builds were failing for detox 0.72 because of duplicated libfbjni.so.


Very similar to PR https://github.com/ammarahm-ed/react-native-mmkv-storage/pull/336