### PR TITLE
Add more native access methods for android

### DIFF
--- a/android/src/main/java/com/ammarahmed/mmkv/MMKV.java
+++ b/android/src/main/java/com/ammarahmed/mmkv/MMKV.java
@@ -3,10 +3,8 @@ package com.ammarahmed.mmkv;
 import android.content.Context;
 import android.os.Parcel;
 import android.os.Parcelable;
-
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
-
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
@@ -215,7 +213,7 @@ public class MMKV {
 
     private native double decodeDouble(long handle, String key, double defaultValue);
 
-    public void encode(String key, @Nullable String value) {
+    public boolean encode(String key, @Nullable String value) {
         return encodeString(nativeHandle, key, value);
     }
 

--- a/android/src/main/java/com/ammarahmed/mmkv/MMKV.java
+++ b/android/src/main/java/com/ammarahmed/mmkv/MMKV.java
@@ -215,9 +215,8 @@ public class MMKV {
 
     private native double decodeDouble(long handle, String key, double defaultValue);
 
-    public void putString(String key, @Nullable String value) {
-        encodeString(nativeHandle, key, value);
-
+    public void encode(String key, @Nullable String value) {
+        return encodeString(nativeHandle, key, value);
     }
 
     private native boolean encodeString(long handle, String key, @Nullable String value);
@@ -228,6 +227,11 @@ public class MMKV {
 
     private native boolean encodeDouble(long handle, String key, double value);
 
+    public boolean encode(String key, int value) {
+        return encodeInt(nativeHandle, key, value);
+    }
+
+    private native boolean encodeInt(long handle, String key, int value);
 
     public boolean encode(String key, @Nullable Set<String> value) {
         return encodeSet(nativeHandle, key, (value == null) ? null : value.toArray(new String[0]));

--- a/android/src/main/java/com/ammarahmed/mmkv/MMKV.java
+++ b/android/src/main/java/com/ammarahmed/mmkv/MMKV.java
@@ -205,6 +205,16 @@ public class MMKV {
 
     private native int decodeInt(long handle, String key, int defaultValue);
 
+    public double decodeDouble(String key) {
+        return decodeDouble(nativeHandle, key, 0);
+    }
+
+    public double decodeDouble(String key, double defaultValue) {
+        return decodeDouble(nativeHandle, key, defaultValue);
+    }
+
+    private native double decodeDouble(long handle, String key, double defaultValue);
+
     public void putString(String key, @Nullable String value) {
         encodeString(nativeHandle, key, value);
 

--- a/android/src/main/java/com/ammarahmed/mmkv/MMKV.java
+++ b/android/src/main/java/com/ammarahmed/mmkv/MMKV.java
@@ -225,6 +225,25 @@ public class MMKV {
 
     private native boolean encodeSet(long handle, String key, @Nullable String[] value);
 
+    @Nullable
+    public native String[] getAllKeys(long handle);
 
+    @NonNull
+    public Set<String> getAllKeys() {
+        String[] result = getAllKeys(nativeHandle);
 
+        if(result == null) {
+            return Collections.emptySet();
+        }
+
+        return new HashSet<>(Arrays.asList(result));
+    }
+
+    @Nullable
+    private native String decodeString(long handle, String key, String defaultValue);
+
+    @Nullable
+    public String decodeString(String key, @Nullable String defaultValue) {
+        return decodeString(nativeHandle, key, defaultValue);
+    }
 }

--- a/android/src/main/java/com/ammarahmed/mmkv/RNMMKVModule.java
+++ b/android/src/main/java/com/ammarahmed/mmkv/RNMMKVModule.java
@@ -108,7 +108,7 @@ public class RNMMKVModule extends ReactContextBaseJavaModule {
                 }
                 Gson gson = new Gson();
                 String json = gson.toJson(child);
-                kv.putString(key, json);
+                kv.encode(key, json);
                 
                 if (isEncrypted) {
                     String alias = (String) child.get("alias");
@@ -137,7 +137,7 @@ public class RNMMKVModule extends ReactContextBaseJavaModule {
                 if (bundle != null) {
                     WritableMap map = Arguments.fromBundle(bundle);
                     String obj = gson.toJson(map.toHashMap());
-                    kvv.putString(string, obj);
+                    kvv.encode(string, obj);
                 }
 
             }
@@ -152,7 +152,7 @@ public class RNMMKVModule extends ReactContextBaseJavaModule {
                     if (map.getArray(string) != null) {
                         ArrayList<Object> list = map.getArray(string).toArrayList();
                         String obj = gson.toJson(list);
-                        kvv.putString(string, obj);
+                        kvv.encode(string, obj);
                     }
 
                 }

--- a/android/src/main/rnmmkv/rnmmkv-adapter.cpp
+++ b/android/src/main/rnmmkv/rnmmkv-adapter.cpp
@@ -885,6 +885,24 @@ Java_com_ammarahmed_mmkv_MMKV_decodeInt(JNIEnv *env, jobject obj, jlong handle, 
     return defaultValue;
 }
 
+extern "C"
+JNIEXPORT jdouble JNICALL
+Java_com_ammarahmed_mmkv_MMKV_decodeDouble(JNIEnv *env, jobject obj, jlong handle, jstring oKey,
+                                           jdouble default_value) {
+    MMKV *kv = reinterpret_cast<MMKV *>(handle);
+    if (kv && oKey) {
+        string key = jstring2string(env, oKey);
+        bool hasValue;
+        double value = kv->getDouble(key, 0, &hasValue);
+
+        if (hasValue) {
+            return value;
+        }
+    }
+    return default_value;
+}
+
+
 extern "C" JNIEXPORT jboolean JNICALL
 Java_com_ammarahmed_mmkv_MMKV_checkProcessMode(JNIEnv *env, jclass clazz, jlong handle)
 {

--- a/android/src/main/rnmmkv/rnmmkv-adapter.cpp
+++ b/android/src/main/rnmmkv/rnmmkv-adapter.cpp
@@ -949,6 +949,17 @@ Java_com_ammarahmed_mmkv_MMKV_encodeDouble(JNIEnv *env, jobject thiz, jlong hand
     return (jboolean) false;
 }
 
+extern "C"
+JNIEXPORT jboolean JNICALL
+Java_com_ammarahmed_mmkv_MMKV_encodeInt(JNIEnv *env, jobject thiz, jlong handle, jstring oKey, jint value) {
+    MMKV *kv = reinterpret_cast<MMKV *>(handle);
+    if (kv && oKey) {
+        string key = jstring2string(env, oKey);
+        return (jboolean) kv->set((int) value, key);
+    }
+    return (jboolean) false;
+}
+
 extern "C" JNIEXPORT jboolean JNICALL
 Java_com_ammarahmed_mmkv_MMKV_encodeSet(JNIEnv *env, jobject thiz, jlong handle, jstring oKey,
                                         jobjectArray arrStr)

--- a/android/src/main/rnmmkv/rnmmkv-adapter.cpp
+++ b/android/src/main/rnmmkv/rnmmkv-adapter.cpp
@@ -840,6 +840,21 @@ Java_com_ammarahmed_mmkv_MMKV_removeValueForKey(JNIEnv *env, jobject instance, j
     }
 }
 
+extern "C"
+JNIEXPORT jstring JNICALL
+Java_com_ammarahmed_mmkv_MMKV_decodeString(JNIEnv *env, jobject obj, jlong handle, jstring oKey,
+                                           jstring default_value) {
+    MMKV *kv = reinterpret_cast<MMKV *>(handle);
+    if (kv && oKey) {
+        string key = jstring2string(env, oKey);
+        string value;
+        if (kv->getString(key, value)) {
+            return string2jstring(env, value);
+        }
+    }
+    return default_value;
+}
+
 extern "C" JNIEXPORT jobjectArray JNICALL
 Java_com_ammarahmed_mmkv_MMKV_decodeStringSet(JNIEnv *env, jobject, jlong handle, jstring oKey)
 {
@@ -936,6 +951,18 @@ Java_com_ammarahmed_mmkv_MMKV_encodeSet(JNIEnv *env, jobject thiz, jlong handle,
         }
     }
     return (jboolean) false;
+}
+
+extern "C"
+JNIEXPORT jobjectArray JNICALL
+Java_com_ammarahmed_mmkv_MMKV_getAllKeys(JNIEnv *env, jobject obj, jlong handle) {
+    MMKV *kv = reinterpret_cast<MMKV *>(handle);
+    if (!kv) {
+        return nullptr;
+    }
+    auto keys = kv->allKeys();
+
+    return vector2jarray(env, keys);
 }
 
 extern "C" JNIEXPORT void JNICALL


### PR DESCRIPTION
Adds `getAllKeys` and `decodeString`, `decodeDouble`, and `encode` methods for Int, Double, and String to android to allow reading more values from android native code.

Relates to #217 

If you want to access MMKV before RN is initialized from the android native code, you will need to call load earlier.

Example of new method usage:

```kotlin
 // Load the library (if RN isn't loaded at this point)        
System.loadLibrary("rnmmkv");
MMKV.initialize(this)
val mmkv = MMKV.mmkvWithID("default")!!
val allKeys = mmkv.getAllKeys()
val keyValuePairs = allKeys.associateWith { mmkv.decodeString(it, "") }
Log.w("MyApplication", keyValuePairs.entries.joinToString(",") { "[${it.key}:${it.value}]"})

// Doubles
mmkv.encode("testDouble",60.6)
val doubleValue = mmkv.decodeDouble("testDouble")
Log.w("MyApplication", "doubleValue=$doubleValue")
```