### PR TITLE
remove __turboModuleProxy from jest mock

### DIFF
--- a/jest/mmkvJestSetup.js
+++ b/jest/mmkvJestSetup.js
@@ -2,12 +2,6 @@ if (!global.__fbBatchedBridgeConfig) {
   global.__fbBatchedBridgeConfig = {};
 }
 
-if (!global.__turboModuleProxy) {
-  global.__turboModuleProxy = name => {
-    return {};
-  };
-}
-
 require('react-native').NativeModules.MMKVNative = {
   install: jest.fn(() => true)
 };


### PR DESCRIPTION
## Description
Remove __turboModuleProxy from jest mock.

## Related Issues
Fixes https://github.com/ammarahm-ed/react-native-mmkv-storage/issues/369