### PR TITLE
fix: invalid bin path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "build": "tsc",
     "watch": "tsc --watch"
   },
-  "bin": {
-    "mmkv-link": "./autolink/postlink/run.js"
-  },
   "keywords": [
     "react-native",
     "fast-storage",


### PR DESCRIPTION
Fix invalid bin path in `package.json` causing pnpm to show warnings on installation.

Closes #380