### PR TITLE
Fix mmkv module jest mock

### DIFF
--- a/jest/memoryStore.ts
+++ b/jest/memoryStore.ts
@@ -189,6 +189,13 @@ export const mock = (): boolean => {
     return Object.keys(MEMORY_STORE[id].storage);
   };
 
+  mmkvJsiModule.removeValuesMMKV = (keys, id) => {
+    if (!MEMORY_STORE[id]) return undefined;
+    for (let key of keys) {
+      mmkvJsiModule.removeValueMMKV(key, id);
+    }
+  };
+
   mmkvJsiModule.setupMMKVInstance('mmkvIdStore');
   return true;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -99,7 +99,7 @@ export type MMKVJsiModule = {
   getBoolMMKV: (key: string, id: string) => boolean | null | undefined;
 
   removeValueMMKV: (key: string, id: string) => boolean | undefined;
-  removeValuesMMKV: (...keys: string[]) => boolean | undefined;
+  removeValuesMMKV: (keys: string[], id: string) => boolean | undefined;
 
   getAllKeysMMKV: (id: string) => string[] | undefined;
   getIndexMMKV: (type: IndexType, id: string) => string[] | undefined;


### PR DESCRIPTION
This pull request updates the interface and mock implementation for removing multiple values from the MMKV memory store. The main changes clarify the function signature for batch removal and ensure the mock reflects the new interface.

**API consistency and type safety:**

* Changed the signature of `removeValuesMMKV` in `MMKVJsiModule` to accept an array of keys and an `id`, instead of a variable argument list, improving clarity and type safety (`src/types/index.ts`).

**Mock implementation update:**

* Updated the mock implementation in `jest/memoryStore.ts` to match the new `removeValuesMMKV` signature, iterating over the provided array of keys and removing each from the memory store.

Closes #375